### PR TITLE
fix: include function name in anthropic tool calls stream chunks

### DIFF
--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -201,13 +201,45 @@ export class AnthropicProvider implements IProvider {
                 model: request.model,
                 choices: [
                   {
-                    index: 0,
+                    index: chunk.index,
                     delta: {
                       content: chunk.delta.text,
                     },
                     logprobs: null,
                     finish_reason:
                       chunk.delta.text.trim() === "" ? "stop" : null,
+                  },
+                ],
+              }
+            }
+
+            if (
+              chunk.type == "content_block_start" &&
+              chunk.content_block.type == "tool_use"
+            ) {
+              yield {
+                id: `chunk-${chunkIndex++}`,
+                object: "chat.completion.chunk",
+                created: Math.floor(Date.now() / 1000),
+                model: request.model,
+                choices: [
+                  {
+                    index: chunk.index,
+                    delta: {
+                      tool_calls: [
+                        {
+                          index: 0,
+                          id: chunk.content_block.id,
+                          function: {
+                            arguments: "",
+                            name: chunk.content_block.name
+                          },
+                          type: "function"
+                        }
+                      ]
+                    },
+                    logprobs: null,
+                    finish_reason: null,
                   },
                 ],
               }
@@ -224,7 +256,7 @@ export class AnthropicProvider implements IProvider {
                 model: request.model,
                 choices: [
                   {
-                    index: 0,
+                    index: chunk.index,
                     delta: {
                       tool_calls: [
                         {
@@ -253,7 +285,7 @@ export class AnthropicProvider implements IProvider {
                 model: request.model,
                 choices: [
                   {
-                    index: 0,
+                    index: chunk.index,
                     delta: {},
                     logprobs: null,
                     finish_reason:


### PR DESCRIPTION
Fixes #1

When using tool calls with streaming, the function name was missing from the initial chunk of the tool call response.

Before this fix:
```json
{
  "choices": [{
    "delta": {
      "tool_calls": [{
        "function": {
          "arguments": ""
        }
      }]
    }
  }]
}
```

After this fix:
```json
{
  "choices": [{
    "delta": {
      "tool_calls": [{
        "function": {
          "name": "get_weather",
          "arguments": ""
        }
      }]
    }
  }]
}
```

This PR also fixes the index handling in stream chunks to properly reflect the index from Anthropic's response.